### PR TITLE
FreeBSD Compatibility Patch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ grb: grb.sh grb.awk grb.tsv
 	cat grb.sh > $@
 	echo 'exit 0' >> $@
 	echo "#EOF" >> $@
-	tar cz grb.awk grb.tsv >> $@
+	tar czf - grb.awk grb.tsv >> $@
 	chmod +x $@
 
 test: grb.sh

--- a/grb.sh
+++ b/grb.sh
@@ -5,7 +5,7 @@
 SELF="$0"
 
 get_data() {
-	sed '1,/^#EOF$/d' < "$SELF" | tar xz -O "$1"
+	sed '1,/^#EOF$/d' < "$SELF" | tar xzf - -O "$1"
 }
 
 if [ -z "$PAGER" ]; then


### PR DESCRIPTION
Changed in Makefile & grb.sh: 
_Explicitly set tar output file to standard._

Fixes for FreeBSD. Also tested & working in Manjaro Linux. Changes no operations. 